### PR TITLE
Pagerduty Lib: Improve Error Handling

### DIFF
--- a/client.go
+++ b/client.go
@@ -50,6 +50,10 @@ type errorObject struct {
 	Errors  interface{} `json:"errors,omitempty"`
 }
 
+func (e *errorObject) Error() string {
+	return fmt.Sprintf("Failed to call API endpoint. Error: %v", e)
+}
+
 func newDefaultHTTPClient() *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{
@@ -163,7 +167,7 @@ func (c *Client) checkResponse(resp *http.Response, err error) (*http.Response, 
 		if eo, getErr = c.getErrorFromResponse(resp); getErr != nil {
 			return resp, fmt.Errorf("Response did not contain formatted error: %s. HTTP response code: %v. Raw response: %+v", getErr, resp.StatusCode, resp)
 		}
-		return resp, fmt.Errorf("Failed call API endpoint. HTTP response code: %v. Error: %v", resp.StatusCode, eo)
+		return resp, eo
 	}
 	return resp, nil
 }

--- a/client.go
+++ b/client.go
@@ -44,13 +44,13 @@ type APIDetails struct {
 	Details string `json:"details,omitempty"`
 }
 
-type errorObject struct {
+type APIError struct {
 	Code    int         `json:"code,omitempty"`
 	Message string      `json:"message,omitempty"`
 	Errors  interface{} `json:"errors,omitempty"`
 }
 
-func (e *errorObject) Error() string {
+func (e *APIError) Error() string {
 	return fmt.Sprintf("Failed to call API endpoint. Error: %v", e)
 }
 
@@ -162,7 +162,7 @@ func (c *Client) checkResponse(resp *http.Response, err error) (*http.Response, 
 		return resp, fmt.Errorf("Error calling the API endpoint: %v", err)
 	}
 	if 199 >= resp.StatusCode || 300 <= resp.StatusCode {
-		var eo *errorObject
+		var eo *APIError
 		var getErr error
 		if eo, getErr = c.getErrorFromResponse(resp); getErr != nil {
 			return resp, fmt.Errorf("Response did not contain formatted error: %s. HTTP response code: %v. Raw response: %+v", getErr, resp.StatusCode, resp)
@@ -172,8 +172,8 @@ func (c *Client) checkResponse(resp *http.Response, err error) (*http.Response, 
 	return resp, nil
 }
 
-func (c *Client) getErrorFromResponse(resp *http.Response) (*errorObject, error) {
-	var result map[string]errorObject
+func (c *Client) getErrorFromResponse(resp *http.Response) (*APIError, error) {
+	var result map[string]APIError
 	if err := c.decodeJSON(resp, &result); err != nil {
 		return nil, fmt.Errorf("Could not decode JSON response: %v", err)
 	}


### PR DESCRIPTION
The Pagerduty Library handles errors in a way that means you can't get access to underlying error, as it is stripped when using `fmt.Errorf`. 

This is hugely problematic for us, as it means, without regex, that is liable to breaking, you can't perform custom logic depending on what type of error we've hit. For example, we might want our application to continue gracefully in the event of a NotFound error. 

This PR makes the current error object implementation meet the Go Error interface, which means we don't need to wrap it using `fmt.Errorf` and can then use type assertion to access the error's attributes.

I'll also start this discussion upstream, but would like to get this merged to unblock an internal project for user management. 