### PR TITLE
Pagerduty: Use e.Message, rather than the error itself

### DIFF
--- a/client.go
+++ b/client.go
@@ -51,7 +51,7 @@ type APIError struct {
 }
 
 func (e *APIError) Error() string {
-	return fmt.Sprintf("Failed to call API endpoint. Error: %v", e)
+	return fmt.Sprintf("Failed to call API endpoint. Error: %s", e.Message)
 }
 
 func newDefaultHTTPClient() *http.Client {


### PR DESCRIPTION
This PR changes Pagerduty to use e.Message, rather than the error itself when returning an error. 