### PR TITLE
AEHUB - 2682 - Adding update incident endpoint

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -327,16 +327,11 @@ type UpdateIncidentOptions struct {
 func (c *Client) UpdateIncident(id string, o *UpdateIncidentOptions) (*UpdateIncidentResponse, error) {
 	data := make(map[string]*UpdateIncidentOptions)
 	data["incident"] = o
-	resp, e := c.put("/incidents/"+id, data, nil)
-	if e != nil {
-		return nil, e
+	resp, err := c.put("/incidents/"+id, data, nil)
+	if err != nil {
+		return nil, err
 	}
 
-	var ir UpdateIncidentResponse
-	e = json.NewDecoder(resp.Body).Decode(&ir)
-	if e != nil {
-		return nil, e
-	}
-
-	return &ir, nil
+	var result UpdateIncidentResponse
+	return &result, c.decodeJSON(resp, &result)
 }

--- a/incident.go
+++ b/incident.go
@@ -305,3 +305,38 @@ type ListAlertResponse struct {
 	APIListObject
 	Alerts []Alert `json:"alerts,omitempty"`
 }
+
+// UpdateIncident is not apart of the go-pagerduty library. Therefore, we need to add it manually.
+// https://developer.pagerduty.com/api-reference/8a0e1aa2ec666-update-an-incident
+
+// UpdateIncidentResponse is the response structure when calling the UpdateIncident API endpoint.
+type UpdateIncidentResponse struct {
+	Incident Incident `json:"incident,omitempty"`
+}
+
+// UpdateIncidentOptions is the structure used when passing parameters to the UpdateIncident API endpoint.
+type UpdateIncidentOptions struct {
+	Type            string `url:"type,omitempty"`
+	Urgency         string `url:"urgency,omitempty"`
+	Status          string `url:"status,omitempty"`
+	Resolution      string `url:"resolution,omitempty,brackets"`
+	EscalationLevel int    `url:"escalation_level,omitempty"`
+}
+
+// ListIncidents lists existing incidents.
+func (c *Client) UpdateIncident(id string, o *UpdateIncidentOptions) (*UpdateIncidentResponse, error) {
+	data := make(map[string]*UpdateIncidentOptions)
+	data["incident"] = o
+	resp, e := c.put("/incidents/"+id, data, nil)
+	if e != nil {
+		return nil, e
+	}
+
+	var ir UpdateIncidentResponse
+	e = json.NewDecoder(resp.Body).Decode(&ir)
+	if e != nil {
+		return nil, e
+	}
+
+	return &ir, nil
+}


### PR DESCRIPTION
[JIRA](https://mondough.atlassian.net/jira/software/projects/AEHUB/boards/341?assignee=63bb653994d18cbf677218bf&selectedIssue=AEHUB-2682)

This PR adds the implementation for the /update incident endpoint that is not implemented in our go-pagerduty library (I know we are 4 years out of date - but it is not even the most latest version. I will raise a PR there to add).

https://developer.pagerduty.com/api-reference/8a0e1aa2ec666-update-an-incident