### PR TITLE
Adding from header to update incident endpoint

### DIFF
--- a/incident.go
+++ b/incident.go
@@ -324,10 +324,12 @@ type UpdateIncidentOptions struct {
 }
 
 // ListIncidents lists existing incidents.
-func (c *Client) UpdateIncident(id string, o *UpdateIncidentOptions) (*UpdateIncidentResponse, error) {
+func (c *Client) UpdateIncident(id string, from string, o *UpdateIncidentOptions) (*UpdateIncidentResponse, error) {
 	data := make(map[string]*UpdateIncidentOptions)
 	data["incident"] = o
-	resp, err := c.put("/incidents/"+id, data, nil)
+	headers := make(map[string]string)
+	headers["From"] = from
+	resp, err := c.put("/incidents/"+id, data, &headers)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I forgot to add a required from field to the headers for this request: https://developer.pagerduty.com/api-reference/8a0e1aa2ec666-update-an-incident

<img width="916" alt="Screenshot 2024-06-06 at 13 28 37" src="https://github.com/monzo/go-pagerduty/assets/10059959/ea14aa9d-f17c-4b15-a1fc-1f8ae97d5245">
